### PR TITLE
feat: [007-GROUP/UPDATE] 그룹 수정

### DIFF
--- a/src/main/java/com/valuewith/tweaver/chat/entity/ChatRoom.java
+++ b/src/main/java/com/valuewith/tweaver/chat/entity/ChatRoom.java
@@ -35,4 +35,8 @@ public class ChatRoom extends BaseEntity {
   @OneToOne
   @JoinColumn(name = "trip_group_id")
   private TripGroup tripGroup;
+
+  public void updateChatRoom(TripGroup tripGroup) {
+    this.title = tripGroup.getName();
+  }
 }

--- a/src/main/java/com/valuewith/tweaver/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/valuewith/tweaver/chat/repository/ChatRoomRepository.java
@@ -2,8 +2,10 @@ package com.valuewith.tweaver.chat.repository;
 
 
 import com.valuewith.tweaver.chat.entity.ChatRoom;
+import com.valuewith.tweaver.group.entity.TripGroup;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
-
+  Optional<ChatRoom> findByTripGroup(TripGroup tripGroup);
 }

--- a/src/main/java/com/valuewith/tweaver/chat/service/ChatRoomService.java
+++ b/src/main/java/com/valuewith/tweaver/chat/service/ChatRoomService.java
@@ -3,6 +3,7 @@ package com.valuewith.tweaver.chat.service;
 import com.valuewith.tweaver.chat.entity.ChatRoom;
 import com.valuewith.tweaver.chat.repository.ChatRoomRepository;
 import com.valuewith.tweaver.group.entity.TripGroup;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -21,5 +22,16 @@ public class ChatRoomService {
         .tripGroup(tripGroup)
         .build();
     return chatRoomRepository.save(chatRoom);
+  }
+
+  public void modifiedChatRoom(TripGroup tripGroup) {
+    Optional<ChatRoom> foundChatRoom = chatRoomRepository.findByTripGroup(tripGroup);
+
+    ChatRoom chatRoom = foundChatRoom.orElseThrow(() -> {
+      throw new RuntimeException("수정할 채팅방 데이터가 존재하지 않습니다.");
+    });
+
+    chatRoom.updateChatRoom(tripGroup);
+
   }
 }

--- a/src/main/java/com/valuewith/tweaver/group/controller/GroupController.java
+++ b/src/main/java/com/valuewith/tweaver/group/controller/GroupController.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,7 +32,7 @@ public class GroupController {
   private final GroupMemberService groupMemberService;
 
   @PostMapping
-  public ResponseEntity<?> createGroup(
+  public ResponseEntity<String> createGroup(
       @RequestPart(value = "tripGroupRequestDto") TripGroupRequestDto tripGroupRequestDto,
       @RequestPart(value = "file") MultipartFile file) {
     // 1.그룹 등록
@@ -55,4 +56,18 @@ public class GroupController {
     groupMemberService.createGroupMember(tripGroup, member, chatRoom);
     return ResponseEntity.ok("ok");
   }
+
+  @PutMapping
+  public ResponseEntity<String> modifiedGroup(
+      @RequestPart(value = "tripGroupRequestDto") TripGroupRequestDto tripGroupRequestDto,
+      @RequestPart(value = "file") MultipartFile file) {
+    // 1.그룹 수정
+    TripGroup tripGroup = tripGroupService.modifiedTripGroup(tripGroupRequestDto, file);
+    // 2.여행 수정
+    placeService.modifiedPlace(tripGroup, tripGroupRequestDto.getPlaces());
+    // 3.채팅 수정(그룹명 수정으로 인한 채팅룸 제목 수정)
+    chatRoomService.modifiedChatRoom(tripGroup);
+    return ResponseEntity.ok("ok");
+  }
+
 }

--- a/src/main/java/com/valuewith/tweaver/group/dto/TripGroupRequestDto.java
+++ b/src/main/java/com/valuewith/tweaver/group/dto/TripGroupRequestDto.java
@@ -21,6 +21,7 @@ public class TripGroupRequestDto {
   private String name;
   private String content;
   private Integer maxMemberNumber;
+  private Integer currentMemberNumber;
   private String tripArea;
   private LocalDate tripDate;
   private LocalDate dueDate;

--- a/src/main/java/com/valuewith/tweaver/group/entity/TripGroup.java
+++ b/src/main/java/com/valuewith/tweaver/group/entity/TripGroup.java
@@ -71,15 +71,14 @@ public class TripGroup extends BaseEntity {
         this.thumbnailUrl = tripGroupRequestDto.getThumbnailUrl() == null
             ? this.thumbnailUrl
             : tripGroupRequestDto.getThumbnailUrl();
-        this.status = setGroupStatus();
+        /**
+         * 그룹의 최대 인원 변경으로 인한 그룹 상태변경
+         * 1.최대 인원이 현재 인원과 같은 경우 -> 마감상태로 변경
+         * 2.최대 인원이 현재 인원보다 큰 경우 -> 모집상태로 변경
+         */
+        this.status = this.currentMemberNumber.equals(this.maxMemberNumber)
+            ? GroupStatus.CLOSE
+            : GroupStatus.OPEN;
     }
 
-    public GroupStatus setGroupStatus() {
-        if (this.currentMemberNumber.equals(this.maxMemberNumber)) {
-            return GroupStatus.CLOSE;
-        } else if(this.dueDate.compareTo(this.tripDate) < 0 || LocalDate.now().compareTo(this.dueDate) <= 0) {
-            return GroupStatus.OPEN;
-        }
-        return this.status;
-    }
 }

--- a/src/main/java/com/valuewith/tweaver/group/entity/TripGroup.java
+++ b/src/main/java/com/valuewith/tweaver/group/entity/TripGroup.java
@@ -2,6 +2,7 @@ package com.valuewith.tweaver.group.entity;
 
 import com.valuewith.tweaver.auditing.BaseEntity;
 import com.valuewith.tweaver.constants.GroupStatus;
+import com.valuewith.tweaver.group.dto.TripGroupRequestDto;
 import java.time.LocalDate;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -57,4 +58,28 @@ public class TripGroup extends BaseEntity {
     @NotNull
     @Enumerated(EnumType.STRING)
     private GroupStatus status;
+
+    public void updateTripGroup(TripGroupRequestDto tripGroupRequestDto) {
+        this.name = tripGroupRequestDto.getName();
+        this.content = tripGroupRequestDto.getContent();
+        this.maxMemberNumber = tripGroupRequestDto.getMaxMemberNumber();
+        this.tripArea = tripGroupRequestDto.getTripArea();
+        this.tripDate = tripGroupRequestDto.getTripDate();
+        this.dueDate = tripGroupRequestDto.getDueDate() == null
+            ? tripGroupRequestDto.getTripDate().minusDays(1)
+            : tripGroupRequestDto.getDueDate();
+        this.thumbnailUrl = tripGroupRequestDto.getThumbnailUrl() == null
+            ? this.thumbnailUrl
+            : tripGroupRequestDto.getThumbnailUrl();
+        this.status = setGroupStatus();
+    }
+
+    public GroupStatus setGroupStatus() {
+        if (this.currentMemberNumber.equals(this.maxMemberNumber)) {
+            return GroupStatus.CLOSE;
+        } else if(this.dueDate.compareTo(this.tripDate) < 0 || LocalDate.now().compareTo(this.dueDate) <= 0) {
+            return GroupStatus.OPEN;
+        }
+        return this.status;
+    }
 }

--- a/src/main/java/com/valuewith/tweaver/group/entity/TripGroup.java
+++ b/src/main/java/com/valuewith/tweaver/group/entity/TripGroup.java
@@ -81,10 +81,10 @@ public class TripGroup extends BaseEntity {
      */
     public GroupStatus setGroupStatus() {
         if (this.currentMemberNumber.equals(this.maxMemberNumber)
-            && LocalDate.now().compareTo(this.dueDate) > 0) {
+            || LocalDate.now().isAfter(this.dueDate)) {
             return GroupStatus.CLOSE;
         } else if(!this.currentMemberNumber.equals(this.maxMemberNumber)
-            && LocalDate.now().compareTo(this.dueDate) <= 0){
+            && !LocalDate.now().isAfter(this.dueDate)){
             return GroupStatus.OPEN;
         }
         return this.status;

--- a/src/main/java/com/valuewith/tweaver/group/entity/TripGroup.java
+++ b/src/main/java/com/valuewith/tweaver/group/entity/TripGroup.java
@@ -71,14 +71,26 @@ public class TripGroup extends BaseEntity {
         this.thumbnailUrl = tripGroupRequestDto.getThumbnailUrl() == null
             ? this.thumbnailUrl
             : tripGroupRequestDto.getThumbnailUrl();
-        /**
-         * 그룹의 최대 인원 변경으로 인한 그룹 상태변경
-         * 1.최대 인원이 현재 인원과 같은 경우 -> 마감상태로 변경
-         * 2.최대 인원이 현재 인원보다 큰 경우 -> 모집상태로 변경
-         */
-        this.status = this.currentMemberNumber.equals(this.maxMemberNumber)
-            ? GroupStatus.CLOSE
-            : GroupStatus.OPEN;
+        this.status = setGroupStatus();
     }
 
+    /**
+     * 그룹의 최대 인원 변경으로 인한 그룹 상태변경
+     * 1.최대 인원이 현재 인원과 같은 경우 -> 마감상태로 변경
+     * 2.최대 인원이 현재 인원보다 큰 경우 -> 모집상태로 변경
+     */
+    public GroupStatus setGroupStatus() {
+        GroupStatus resultStatus;
+        if (this.currentMemberNumber.equals(this.maxMemberNumber)) {
+            resultStatus = GroupStatus.CLOSE;
+        } else {
+            resultStatus = GroupStatus.OPEN;
+        }
+
+        if (this.status.equals(resultStatus)) {
+            return this.status;
+        } else {
+            return resultStatus;
+        }
+    }
 }

--- a/src/main/java/com/valuewith/tweaver/group/entity/TripGroup.java
+++ b/src/main/java/com/valuewith/tweaver/group/entity/TripGroup.java
@@ -76,21 +76,17 @@ public class TripGroup extends BaseEntity {
 
     /**
      * 그룹의 최대 인원 변경으로 인한 그룹 상태변경
-     * 1.최대 인원이 현재 인원과 같은 경우 -> 마감상태로 변경
-     * 2.최대 인원이 현재 인원보다 큰 경우 -> 모집상태로 변경
+     * 1.최대 인원이 현재 인원과 같고, 마감 날짜가 현재 날짜보다 빠르다면 -> 마감상태로 변경
+     * 2.최대 인원이 현재 인원보다 크고, 마감 날짜가 현재 날짜와 같거나 늦다면 -> 모집상태로 변경
      */
     public GroupStatus setGroupStatus() {
-        GroupStatus resultStatus;
-        if (this.currentMemberNumber.equals(this.maxMemberNumber)) {
-            resultStatus = GroupStatus.CLOSE;
-        } else {
-            resultStatus = GroupStatus.OPEN;
+        if (this.currentMemberNumber.equals(this.maxMemberNumber)
+            && LocalDate.now().compareTo(this.dueDate) > 0) {
+            return GroupStatus.CLOSE;
+        } else if(!this.currentMemberNumber.equals(this.maxMemberNumber)
+            && LocalDate.now().compareTo(this.dueDate) <= 0){
+            return GroupStatus.OPEN;
         }
-
-        if (this.status.equals(resultStatus)) {
-            return this.status;
-        } else {
-            return resultStatus;
-        }
+        return this.status;
     }
 }

--- a/src/main/java/com/valuewith/tweaver/group/service/TripGroupService.java
+++ b/src/main/java/com/valuewith/tweaver/group/service/TripGroupService.java
@@ -55,7 +55,7 @@ public class TripGroupService {
   public TripGroup modifiedTripGroup(TripGroupRequestDto tripGroupRequestDto, MultipartFile file) {
 
     if (file != null && !file.isEmpty()) {
-      String imageUrl = imageService.uploadImageAndGetUrl(file, ImageType.THUMBNAIL);
+      String imageUrl = imageService.modifiedImageWithFallback(file, tripGroupRequestDto.getThumbnailUrl(), ImageType.THUMBNAIL);
       tripGroupRequestDto.setThumbnailUrl(imageUrl);
     }
 

--- a/src/main/java/com/valuewith/tweaver/group/service/TripGroupService.java
+++ b/src/main/java/com/valuewith/tweaver/group/service/TripGroupService.java
@@ -8,6 +8,7 @@ import com.valuewith.tweaver.defaultImage.service.ImageService;
 import com.valuewith.tweaver.group.dto.TripGroupRequestDto;
 import com.valuewith.tweaver.group.entity.TripGroup;
 import com.valuewith.tweaver.group.repository.TripGroupRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -49,6 +50,24 @@ public class TripGroupService {
         .build();
 
     return tripGroupRepository.save(tripGroup);
+  }
+
+  public TripGroup modifiedTripGroup(TripGroupRequestDto tripGroupRequestDto, MultipartFile file) {
+
+    if (file != null && !file.isEmpty()) {
+      String imageUrl = imageService.uploadImageAndGetUrl(file, ImageType.THUMBNAIL);
+      tripGroupRequestDto.setThumbnailUrl(imageUrl);
+    }
+
+    Optional<TripGroup> foundTripGroup = tripGroupRepository.findById(tripGroupRequestDto.getTripGroupId());
+
+    TripGroup tripGroup = foundTripGroup.orElseThrow(() -> {
+      throw new RuntimeException("수정할 그룹 데이터가 존재하지 않습니다.");
+    });
+
+    tripGroup.updateTripGroup(tripGroupRequestDto);
+
+    return tripGroup;
   }
 
   public String getThumbnailUrl(String tripArea) {

--- a/src/main/java/com/valuewith/tweaver/place/repository/PlaceRepository.java
+++ b/src/main/java/com/valuewith/tweaver/place/repository/PlaceRepository.java
@@ -1,10 +1,12 @@
 package com.valuewith.tweaver.place.repository;
 
+import com.valuewith.tweaver.group.entity.TripGroup;
 import com.valuewith.tweaver.place.entity.Place;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PlaceRepository extends JpaRepository<Place, Long> {
-
+  List<Place> deletePlacesByTripGroup(TripGroup tripGroup);
 }

--- a/src/main/java/com/valuewith/tweaver/place/service/PlaceService.java
+++ b/src/main/java/com/valuewith/tweaver/place/service/PlaceService.java
@@ -4,16 +4,17 @@ import com.valuewith.tweaver.group.entity.TripGroup;
 import com.valuewith.tweaver.place.dto.PlaceDto;
 import com.valuewith.tweaver.place.entity.Place;
 import com.valuewith.tweaver.place.repository.PlaceRepository;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
+@Transactional
 public class PlaceService {
 
   private final PlaceRepository placeRepository;
@@ -32,5 +33,15 @@ public class PlaceService {
                 .build())
         .collect(Collectors.toList());
     placeRepository.saveAll(places);
+  }
+
+  /**
+   * 기존 장소 데이터를 지우고 새로 등록
+   * @param placeDtos
+   */
+  public void modifiedPlace(TripGroup tripGroup, List<PlaceDto> placeDtos) {
+    placeRepository.deletePlacesByTripGroup(tripGroup);
+
+    createPlace(tripGroup, placeDtos);
   }
 }

--- a/src/test/java/com/valuewith/tweaver/group/service/TripGroupServiceTests.java
+++ b/src/test/java/com/valuewith/tweaver/group/service/TripGroupServiceTests.java
@@ -1,11 +1,13 @@
 package com.valuewith.tweaver.group.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.valuewith.tweaver.chat.entity.ChatRoom;
 import com.valuewith.tweaver.chat.repository.ChatRoomRepository;
 import com.valuewith.tweaver.chat.service.ChatRoomService;
+import com.valuewith.tweaver.constants.GroupStatus;
 import com.valuewith.tweaver.group.dto.TripGroupRequestDto;
 import com.valuewith.tweaver.group.entity.TripGroup;
 import com.valuewith.tweaver.group.repository.TripGroupRepository;
@@ -18,7 +20,10 @@ import com.valuewith.tweaver.place.service.PlaceService;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
@@ -44,6 +49,63 @@ public class TripGroupServiceTests {
   ChatRoomService chatRoomService;
   @Autowired
   GroupMemberService groupMemberService;
+
+  TripGroup modifiedTestTripGroup;
+  ChatRoom modifiedChatRoom;
+
+  /**
+   * 그룹 수정 테스트를 위한 사전 그룹 등록 처리
+   */
+  @BeforeEach
+  public void setup() {
+    MockitoAnnotations.openMocks(this);
+    TripGroupRequestDto tripGroupRequestDto = TripGroupRequestDto.builder()
+        .name("서울 경복궁 여행 모임")
+        .content("함께 여행할 동행자 모집합니다! 20대 여성이고, 한복 여행을 하고 싶은분 신청해 주세요.")
+        .maxMemberNumber(30)
+        .tripArea("서울")
+        .tripDate(LocalDate.parse("2023-12-13"))
+        .dueDate(LocalDate.parse("2023-12-12"))
+        .build();
+
+    MockMultipartFile file = new MockMultipartFile(
+        "image", "test.jpeg", "image/jpeg", "image_content".getBytes()
+    );
+
+    modifiedTestTripGroup = tripGroupService.createTripGroup(tripGroupRequestDto, file);
+
+    List<PlaceDto> places = new ArrayList<>();
+    places.add(PlaceDto.builder()
+        .name("경복궁 카페")
+        .x(137.123523)
+        .y(36.930291)
+        .address("서울특별시 종로구 삼청로 24")
+        .placeCode("1233456")
+        .orders(3)
+        .build());
+
+    places.add(PlaceDto.builder()
+        .name("경복궁 관훈점")
+        .x(137.146235)
+        .y(36.843464)
+        .address("서울특별시 종로구 인사동5길 38 센터마크호텔 B1")
+        .placeCode("1111111")
+        .orders(1)
+        .build());
+
+    places.add(PlaceDto.builder()
+        .name("경복궁")
+        .x(137.444444)
+        .y(36.555555)
+        .address("서울특별시 종로구 사직로 161")
+        .placeCode("9999999")
+        .orders(2)
+        .build());
+
+    placeService.createPlace(modifiedTestTripGroup, places);
+
+    modifiedChatRoom = chatRoomService.createChatRoom(modifiedTestTripGroup);
+  }
 
   /**
    * 그룹 등록시, 사용자에게 사진을 등록 받은 경우
@@ -177,7 +239,7 @@ public class TripGroupServiceTests {
 
     //then
     List<Place> all = placeRepository.findAll();
-    assertEquals(all.size(), 3);
+    assertEquals(all.size(), 6);
   }
 
   @Test
@@ -246,4 +308,299 @@ public class TripGroupServiceTests {
 //    assertNotNull(groupMember);
 //
 //  }
+
+  /**
+   * 그룹 수정시 max를 current보다 크게 변경
+   */
+  @Test
+  void modifiedTripGroup() {
+    //given
+    TripGroupRequestDto tripGroupRequestDto = TripGroupRequestDto.builder()
+        .tripGroupId(modifiedTestTripGroup.getTripGroupId())
+        .name("그룹명 수정")
+        .content("코멘트 수정")
+        .maxMemberNumber(25)
+        .tripArea("경기도")
+        .tripDate(LocalDate.parse("2023-11-17"))
+        .dueDate(LocalDate.parse("2023-11-11"))
+        .build();
+
+    tripGroupService.modifiedTripGroup(tripGroupRequestDto, null);
+
+    //when
+    Optional<TripGroup> foundTripGroup = tripGroupRepository.findById(modifiedTestTripGroup.getTripGroupId());
+
+    //then
+    foundTripGroup.ifPresent(tripGroup -> {
+      assertEquals("그룹명 수정", tripGroup.getName());
+      assertEquals("코멘트 수정", tripGroup.getContent());
+      assertEquals(25, tripGroup.getMaxMemberNumber());
+      assertEquals("경기도", tripGroup.getTripArea());
+      assertEquals(LocalDate.of(2023, 11, 17), tripGroup.getTripDate());
+      assertEquals(LocalDate.of(2023, 11, 11), tripGroup.getDueDate());
+    });
+
+  }
+
+  /**
+   * 그룹 수정시 max를 current랑 같게 변경 -> 그룹 상태 마감으로 변경된 것 확인
+   */
+  @Test
+  void modifiedTripGroupEqualCurrentAndMax() {
+    //given
+    TripGroupRequestDto tripGroupRequestDto = TripGroupRequestDto.builder()
+        .tripGroupId(modifiedTestTripGroup.getTripGroupId())
+        .name("그룹 수정시 max를 current랑 같게 변경")
+        .content("코멘트 수정")
+        .maxMemberNumber(0)
+        .tripArea("경기도")
+        .tripDate(LocalDate.parse("2023-11-17"))
+        .dueDate(LocalDate.parse("2023-11-11"))
+        .build();
+
+    tripGroupService.modifiedTripGroup(tripGroupRequestDto, null);
+
+    //when
+    Optional<TripGroup> foundTripGroup = tripGroupRepository.findById(modifiedTestTripGroup.getTripGroupId());
+
+    //then
+    foundTripGroup.ifPresent(tripGroup -> {
+      assertEquals(0, tripGroup.getMaxMemberNumber());
+      assertEquals(0, tripGroup.getCurrentMemberNumber());
+      assertEquals(GroupStatus.CLOSE, tripGroup.getStatus());
+    });
+  }
+
+  /**
+   * thumbnail사진 없이 수정 -> 수정전 thumbnail_url과 같아야 함
+   */
+  @Test
+  void modifiedTripGroupNoThumbnail() {
+    //given
+    String beforeUrl = modifiedTestTripGroup.getThumbnailUrl();
+
+    TripGroupRequestDto tripGroupRequestDto = TripGroupRequestDto.builder()
+        .tripGroupId(modifiedTestTripGroup.getTripGroupId())
+        .name("썸네일 파일 없는 수정")
+        .content("코멘트 수정")
+        .maxMemberNumber(25)
+        .tripArea("경기도")
+        .tripDate(LocalDate.parse("2023-11-17"))
+        .dueDate(LocalDate.parse("2023-11-11"))
+        .build();
+
+    tripGroupService.modifiedTripGroup(tripGroupRequestDto, null);
+
+    //when
+    Optional<TripGroup> foundTripGroup = tripGroupRepository.findById(modifiedTestTripGroup.getTripGroupId());
+
+    //then
+    foundTripGroup.ifPresent(tripGroup -> {
+      assertEquals("썸네일 파일 없는 수정", tripGroup.getName());
+      assertEquals(beforeUrl, tripGroup.getThumbnailUrl());
+    });
+  }
+
+//  /**
+//   * thumbnail사진 수정 -> 수정전 Url과 달라야 함.
+//   * 실제로 S3에 있는 값을 테스트 확인 완료
+//   * 테스트 할 때마다 실제로 S3에 있는 url을 가지고 테스트 해야함.
+//   */
+//  @Test
+//  void modifiedTripGroupThumbnail() {
+//    //given
+//    String beforeUrl = modifiedTestTripGroup.getThumbnailUrl();
+//
+//    TripGroupRequestDto tripGroupRequestDto = TripGroupRequestDto.builder()
+//        .tripGroupId(modifiedTestTripGroup.getTripGroupId())
+//        .name("썸네일 파일 있는 수정")
+//        .content("코멘트 수정")
+//        .maxMemberNumber(25)
+//        .tripArea("경기도")
+//        .tripDate(LocalDate.parse("2023-11-17"))
+//        .dueDate(LocalDate.parse("2023-11-11"))
+//        .thumbnailUrl("https://d1udi89ozp4mef.cloudfront.net/thumbnail%2Fd19609e2-c20f-4cb0-9ed0-85382708b5bb-Sketchpad.png")
+//        .build();
+//
+//    MockMultipartFile file = new MockMultipartFile(
+//        "image", "test.jpeg", "image/jpeg", "image_content".getBytes()
+//    );
+//
+//    tripGroupService.modifiedTripGroup(tripGroupRequestDto, file);
+//
+//    //when
+//    Optional<TripGroup> foundTripGroup = tripGroupRepository.findById(modifiedTestTripGroup.getTripGroupId());
+//
+//    //then
+//    foundTripGroup.ifPresent(tripGroup -> {
+//      assertEquals("썸네일 파일 있는 수정", tripGroup.getName());
+//      assertNotEquals(beforeUrl, tripGroup.getThumbnailUrl());
+//    });
+//  }
+
+  /**
+   * dueDate없이 수정 -> 여행날짜의 하루 전으로 등록
+   */
+  @Test
+  void modifiedTripNoDueDate() {
+    //given
+    TripGroupRequestDto tripGroupRequestDto = TripGroupRequestDto.builder()
+        .tripGroupId(modifiedTestTripGroup.getTripGroupId())
+        .name("dueDate없이 수정")
+        .content("코멘트 수정")
+        .maxMemberNumber(25)
+        .tripArea("경기도")
+        .tripDate(LocalDate.parse("2023-12-17"))
+        .build();
+
+    tripGroupService.modifiedTripGroup(tripGroupRequestDto, null);
+
+    //when
+    Optional<TripGroup> foundTripGroup = tripGroupRepository.findById(modifiedTestTripGroup.getTripGroupId());
+
+    //then
+    foundTripGroup.ifPresent(tripGroup -> {
+      assertEquals("dueDate없이 수정", tripGroup.getName());
+      assertNotEquals(new LocalDate[2023-12-17], tripGroup.getTripDate());
+      assertNotEquals(new LocalDate[2023-12-16], tripGroup.getDueDate());
+    });
+  }
+
+  /**
+   * dueDate를 현재 날짜 보다 늦게 변경 -> 모집 상태를 모집중으로 변경
+   */
+  @Test
+  void modifiedTripDueDateLate() {
+    //given
+    TripGroupRequestDto tripGroupRequestDto = TripGroupRequestDto.builder()
+        .tripGroupId(modifiedTestTripGroup.getTripGroupId())
+        .name("dueDate를 현재 날짜 보다 늦게 변경")
+        .content("코멘트 수정")
+        .maxMemberNumber(25)
+        .tripArea("경기도")
+        .tripDate(LocalDate.parse("2023-12-22"))
+        .dueDate(LocalDate.parse("2023-12-19"))
+        .build();
+
+    tripGroupService.modifiedTripGroup(tripGroupRequestDto, null);
+
+    //when
+    Optional<TripGroup> foundTripGroup = tripGroupRepository.findById(modifiedTestTripGroup.getTripGroupId());
+
+    //then
+    foundTripGroup.ifPresent(tripGroup -> {
+      assertEquals("dueDate를 현재 날짜 보다 늦게 변경", tripGroup.getName());
+      assertEquals(GroupStatus.OPEN, tripGroup.getStatus());
+    });
+  }
+
+  /**
+   * dueDate를 현재 날짜 보다 빠르게 변경 -> 모집 상태를 마감으로 변경
+   */
+  @Test
+  void modifiedTripDueDateFast() {
+    //given
+    TripGroupRequestDto tripGroupRequestDto = TripGroupRequestDto.builder()
+        .tripGroupId(modifiedTestTripGroup.getTripGroupId())
+        .name("dueDate를 현재 날짜 보다 빠르게 변경")
+        .content("코멘트 수정")
+        .maxMemberNumber(25)
+        .tripArea("경기도")
+        .tripDate(LocalDate.parse("2023-12-22"))
+        .dueDate(LocalDate.parse("2023-10-19"))
+        .build();
+
+    tripGroupService.modifiedTripGroup(tripGroupRequestDto, null);
+
+    //when
+    Optional<TripGroup> foundTripGroup = tripGroupRepository.findById(modifiedTestTripGroup.getTripGroupId());
+
+    //then
+    foundTripGroup.ifPresent(tripGroup -> {
+      assertEquals("dueDate를 현재 날짜 보다 빠르게 변경", tripGroup.getName());
+      assertEquals(GroupStatus.CLOSE, tripGroup.getStatus());
+    });
+  }
+
+  /**
+   * place가 3개 였던걸 4개로 수정.
+   */
+  @Test
+  void modifiedPlaces() {
+    //given
+    List<PlaceDto> places = new ArrayList<>();
+    places.add(PlaceDto.builder()
+        .name("경복궁 카페 수정")
+        .x(137.123523)
+        .y(36.930291)
+        .address("서울특별시 종로구 삼청로 24")
+        .placeCode("1233456")
+        .orders(2)
+        .build());
+
+    places.add(PlaceDto.builder()
+        .name("경복궁 관훈점")
+        .x(137.146235)
+        .y(36.843464)
+        .address("서울특별시 종로구 인사동5길 38 센터마크호텔 B1")
+        .placeCode("1111111")
+        .orders(3)
+        .build());
+
+    places.add(PlaceDto.builder()
+        .name("경복궁")
+        .x(137.444444)
+        .y(36.555555)
+        .address("서울특별시 종로구 사직로 161")
+        .placeCode("9999999")
+        .orders(1)
+        .build());
+
+    places.add(PlaceDto.builder()
+        .name("경복궁 수정 수정")
+        .x(137.444444)
+        .y(36.555555)
+        .address("서울특별시 종로구 사직로 161")
+        .placeCode("9999999")
+        .orders(4)
+        .build());
+
+    //when
+    placeService.modifiedPlace(modifiedTestTripGroup, places);
+
+    //then -> 삭제된 3개 + 새로 추가된 4개 = 7개
+    List<Place> all = placeRepository.findAll();
+    assertEquals(7, all.size());
+  }
+
+  /**
+   * tripGroup에서 그룹명이 변경될 시, 채팅명도 변경됨.
+   */
+  @Test
+  void modifiedChatRoom() {
+    //given
+    TripGroupRequestDto tripGroupRequestDto = TripGroupRequestDto.builder()
+        .tripGroupId(modifiedTestTripGroup.getTripGroupId())
+        .name("채팅명 변경 확인")
+        .content("코멘트 수정")
+        .maxMemberNumber(25)
+        .tripArea("경기도")
+        .tripDate(LocalDate.parse("2023-12-22"))
+        .dueDate(LocalDate.parse("2023-10-19"))
+        .build();
+
+    tripGroupService.modifiedTripGroup(tripGroupRequestDto, null);
+
+    Optional<TripGroup> foundTripGroup = tripGroupRepository.findById(modifiedTestTripGroup.getTripGroupId());
+
+    //when
+    //then
+    foundTripGroup.ifPresent(tripGroup -> {
+      chatRoomService.modifiedChatRoom(tripGroup);
+      chatRoomRepository.findByTripGroup(tripGroup).ifPresent(chatRoom -> {
+        assertEquals("채팅명 변경 확인", chatRoom.getTitle());
+      });
+    });
+
+  }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
 - 그룹 등록 처리
 
**TO-BE**
 - 스케줄러 사용해서 매일 오전 12시에 마감날짜 지난 그룹 상태변경 
 - 그룹 삭제

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- 기본 그룹 수정 내용 확인
- max를 current와 같게 수정 -> 그룹 상태 마감으로 변경되는 것 확인
- thumbnail사진 없이 수정 -> 수정전과 수정후의 thumbnail_url 같음 확인
- thumbnail사진 있이 수정 -> 수정전과 수정후의 thumbnail_url 다름 확인
- dueDate없이 수정 -> 여행날짜의 하루 전으로 변경됨 확인
- dueDate를 현재 날짜 보다 늦게 변경 -> 모집 상태가 모집중으로 변경됨 확인
- dueDate를 현재 날짜 보다 빠르게 변경 -> 모집 상태가 마감으로 변경됨 확인
- place가 3개 였던 것을 4개로 변경 -> 삭제 데이터3개 + 수정으로 등록된 데이터 4개 = 총 7개가 존재하는 것 확인
- 그룹 수정시 그룹명이 변경될 시, 채팅명도 변경됨 확인

- [x] API 테스트 