### PR TITLE
refactor: [004-SIGNUP-001-REFACTOR] 패키지명 변경과 회원가입 기능 리팩토링

### DIFF
--- a/src/main/java/com/valuewith/tweaver/alert/entity/Alert.java
+++ b/src/main/java/com/valuewith/tweaver/alert/entity/Alert.java
@@ -1,7 +1,7 @@
 package com.valuewith.tweaver.alert.entity;
 
 import com.valuewith.tweaver.auditing.BaseEntity;
-import com.valuewith.tweaver.menber.entity.Member;
+import com.valuewith.tweaver.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/valuewith/tweaver/auth/controller/AuthController.java
+++ b/src/main/java/com/valuewith/tweaver/auth/controller/AuthController.java
@@ -1,24 +1,19 @@
 package com.valuewith.tweaver.auth.controller;
 
-import com.valuewith.tweaver.auth.dto.AuthDto.*;
+import com.valuewith.tweaver.auth.dto.AuthDto.EmailInput;
+import com.valuewith.tweaver.auth.dto.AuthDto.SignUpForm;
+import com.valuewith.tweaver.auth.dto.AuthDto.VerificationForm;
 import com.valuewith.tweaver.auth.service.AuthService;
-import com.valuewith.tweaver.user.entity.Member;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping(value = "/auth", produces = "application/text; charset=utf8")
+@RequestMapping(value = "/auth", produces = "application/json; charset=utf8")
 public class AuthController {
 
   private final AuthService authService;
@@ -26,17 +21,17 @@ public class AuthController {
   // TODO: 회원가입(등록), 이메일 인증
 
   @PostMapping(value = "/signup")
-  public ResponseEntity<String> signUp(SignUpForm request, MultipartFile file) {
+  public ResponseEntity<EmailInput> signUp(SignUpForm request, MultipartFile file) {
     return ResponseEntity.ok(authService.signUp(request, file));
   }
 
   @PostMapping("/verify")
-  public void sendCode(@RequestBody EmailInput request) {
+  public void sendCode(EmailInput request) {
     authService.sendEmailVerification(request);
   }
 
   @PostMapping("/verify/check")
-  public ResponseEntity<Boolean> checkCode(@RequestBody VerificationForm request) {
+  public ResponseEntity<Boolean> checkCode(VerificationForm request) {
     return ResponseEntity.ok(authService.isVerified(request));  // true
   }
 }

--- a/src/main/java/com/valuewith/tweaver/auth/dto/AuthDto.java
+++ b/src/main/java/com/valuewith/tweaver/auth/dto/AuthDto.java
@@ -1,6 +1,8 @@
 package com.valuewith.tweaver.auth.dto;
 
-import com.valuewith.tweaver.user.entity.Member;
+import com.valuewith.tweaver.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -18,7 +20,8 @@ public class AuthDto {
     private String gender;
     private Integer age;
 
-    public Member toEntity(String profileUrl) {
+    // TODO: to 메소드 사용법 변경
+    public Member setProfileUrl(String profileUrl) {
       return Member.builder()
           .nickName(this.nickname)
           .email(this.email)
@@ -40,7 +43,15 @@ public class AuthDto {
 
   @Data
   @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
   public static class EmailInput {
     private String email;
+
+    public static EmailInput from(Member member) {
+      return EmailInput.builder()
+          .email(member.getEmail())
+          .build();
+    }
   }
 }

--- a/src/main/java/com/valuewith/tweaver/auth/service/AuthService.java
+++ b/src/main/java/com/valuewith/tweaver/auth/service/AuthService.java
@@ -34,6 +34,7 @@ public class AuthService {
       profileUrl = imageService.uploadImageAndGetUrl(file, ImageType.MEMBER);
     } else {
       // 사진을 못받은 경우 기본 이미지 등록
+      // TODO: 기본 프로필 이미지 업로드 되면 다시 확인
       DefaultImage defaultImg = defaultImageRepository.findRandomByImageName("멤버");
       profileUrl = defaultImg.getDefaultImageUrl();
     }

--- a/src/main/java/com/valuewith/tweaver/group/controller/GroupController.java
+++ b/src/main/java/com/valuewith/tweaver/group/controller/GroupController.java
@@ -2,13 +2,12 @@ package com.valuewith.tweaver.group.controller;
 
 import com.valuewith.tweaver.chat.entity.ChatRoom;
 import com.valuewith.tweaver.chat.service.ChatRoomService;
-import com.valuewith.tweaver.constants.ImageType;
 import com.valuewith.tweaver.defaultImage.service.ImageService;
 import com.valuewith.tweaver.group.dto.TripGroupRequestDto;
 import com.valuewith.tweaver.group.entity.TripGroup;
 import com.valuewith.tweaver.group.service.TripGroupService;
 import com.valuewith.tweaver.groupMember.service.GroupMemberService;
-import com.valuewith.tweaver.menber.entity.Member;
+import com.valuewith.tweaver.member.entity.Member;
 import com.valuewith.tweaver.place.service.PlaceService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/valuewith/tweaver/groupMember/entity/GroupMember.java
+++ b/src/main/java/com/valuewith/tweaver/groupMember/entity/GroupMember.java
@@ -6,7 +6,7 @@ import com.valuewith.tweaver.constants.ApprovedStatus;
 import com.valuewith.tweaver.constants.MemberRole;
 import com.valuewith.tweaver.group.entity.TripGroup;
 import com.valuewith.tweaver.message.entity.Message;
-import com.valuewith.tweaver.menber.entity.Member;
+import com.valuewith.tweaver.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/valuewith/tweaver/groupMember/service/GroupMemberService.java
+++ b/src/main/java/com/valuewith/tweaver/groupMember/service/GroupMemberService.java
@@ -6,7 +6,7 @@ import com.valuewith.tweaver.constants.MemberRole;
 import com.valuewith.tweaver.group.entity.TripGroup;
 import com.valuewith.tweaver.groupMember.entity.GroupMember;
 import com.valuewith.tweaver.groupMember.repository.GroupMemberRepository;
-import com.valuewith.tweaver.menber.entity.Member;
+import com.valuewith.tweaver.member.entity.Member;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/valuewith/tweaver/member/dto/MemberDto.java
+++ b/src/main/java/com/valuewith/tweaver/member/dto/MemberDto.java
@@ -1,4 +1,4 @@
-package com.valuewith.tweaver.menber.dto;
+package com.valuewith.tweaver.member.dto;
 
 import com.valuewith.tweaver.alert.dto.AlertDto;
 import com.valuewith.tweaver.groupMember.dto.GroupMemberDto;

--- a/src/main/java/com/valuewith/tweaver/member/entity/Member.java
+++ b/src/main/java/com/valuewith/tweaver/member/entity/Member.java
@@ -1,4 +1,4 @@
-package com.valuewith.tweaver.menber.entity;
+package com.valuewith.tweaver.member.entity;
 
 import com.valuewith.tweaver.auditing.BaseEntity;
 import lombok.*;

--- a/src/main/java/com/valuewith/tweaver/member/repository/MemberRepository.java
+++ b/src/main/java/com/valuewith/tweaver/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.valuewith.tweaver.member.repository;
+
+import com.valuewith.tweaver.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+  Boolean existsByEmail(String email);
+
+}

--- a/src/main/java/com/valuewith/tweaver/user/repository/UserRepository.java
+++ b/src/main/java/com/valuewith/tweaver/user/repository/UserRepository.java
@@ -1,9 +1,0 @@
-package com.valuewith.tweaver.user.repository;
-
-import com.valuewith.tweaver.user.entity.Member;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface UserRepository extends JpaRepository<Member, Long> {
-  Boolean existsByEmail(String email);
-
-}

--- a/src/test/java/com/valuewith/tweaver/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/valuewith/tweaver/auth/controller/AuthControllerTest.java
@@ -1,0 +1,48 @@
+package com.valuewith.tweaver.auth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.valuewith.tweaver.auth.service.AuthService;
+import com.valuewith.tweaver.defaultImage.service.ImageService;
+import com.valuewith.tweaver.exception.GlobalExceptionHandler;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AuthController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureMockMvc
+class AuthControllerTest {
+
+  @MockBean
+  AuthService authService;
+  @MockBean
+  ImageService imageService;
+  @MockBean
+  GlobalExceptionHandler globalExceptionHandler;
+
+  @Autowired
+  ObjectMapper objectMapper;
+  @Autowired
+  MockMvc mockMvc;
+
+  @Test
+  @WithMockUser
+  @DisplayName("회원가입 성공-이미지 있음")
+  void success_signup_test_with_image() throws Exception {
+    /**
+     * 회원가입 성공여부는 SignUpForm 필드가 모두 작성될 경우입니다.
+     * 이미지가 있는 경우
+     */
+    //given
+    //when
+    //then
+
+
+  }
+}

--- a/src/test/java/com/valuewith/tweaver/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/valuewith/tweaver/auth/service/AuthServiceTest.java
@@ -1,0 +1,32 @@
+package com.valuewith.tweaver.auth.service;
+
+import com.valuewith.tweaver.defaultImage.service.ImageService;
+import com.valuewith.tweaver.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class AuthServiceTest {
+
+  static {
+    System.setProperty("com.amazonaws.sdk.disableEc2Metadata", "true");
+  }
+
+  @Autowired
+  MemberRepository memberRepository;
+  @Autowired
+  AuthService authService;
+  @Autowired
+  ImageService imageService;
+
+  @Test
+  @DisplayName("회원가입 성공 테스트")
+  void signup_test() throws Exception {
+    // given
+    // when
+    // then
+  }
+
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- AuthService의 signup 메서드 리턴타입을 EmailInput으로 변경했습니다.
    - 회원가입 완료시 이메일 주소만 response에 담아 보냅니다.
- AuthController의 RestController produce 값을 application/json으로 변경했습니다.
    - 프로젝트내 다른 서비스와 일관성을 유지하기 위해 변경했습니다.
- AuthDto내에 데이터 이동을 원활히 하기 위해 메서드를 추가했습니다. (10월 31일 이후 메서드 네이밍 컨벤션에 따름)
    - toEntity() → setProfileUrl() : 메서드 기능을 더욱 구체적으로 표현했습니다.
    - EmailInput에 from() 메서드를 추가하였습니다.

**TO-BE**
- 메서드 네이밍 컨벤션을 정해 코드의 일관성을 유지할 수 있을 것 같습니다.
- 네이밍이 아직 익숙치 않습니다. 혹시 변경할 부분이 있으면 리뷰때 알려주세요. 곧바로 수정하겠습니다.
- 회원가입 기능의 응답값으로 이메일을 보내주면 프론트에서 유용하게 사용할 수 있을 것 같습니다. **(논의 필요)**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트
    - Swagger 테스트 완료
    - Postman 테스트 필요 