### PR TITLE
feat: [015-SIGNIN] 로그인 기능 추가

### DIFF
--- a/src/main/java/com/valuewith/tweaver/auth/controller/AuthController.java
+++ b/src/main/java/com/valuewith/tweaver/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.valuewith.tweaver.auth.controller;
 
+import com.valuewith.tweaver.auth.dto.AuthDto;
 import com.valuewith.tweaver.auth.dto.AuthDto.EmailInput;
 import com.valuewith.tweaver.auth.dto.AuthDto.SignUpForm;
 import com.valuewith.tweaver.auth.dto.AuthDto.VerificationForm;
@@ -7,6 +8,7 @@ import com.valuewith.tweaver.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -18,7 +20,10 @@ public class AuthController {
 
   private final AuthService authService;
 
-  // TODO: 회원가입(등록), 이메일 인증
+  @PostMapping(value = "/signin")
+  public ResponseEntity<String> signIn(@RequestBody AuthDto.SignInForm request) {
+    return ResponseEntity.ok(authService.authenticate(request));
+  }
 
   @PostMapping(value = "/signup")
   public void signUp(SignUpForm request, MultipartFile file) {

--- a/src/main/java/com/valuewith/tweaver/auth/controller/AuthController.java
+++ b/src/main/java/com/valuewith/tweaver/auth/controller/AuthController.java
@@ -5,6 +5,8 @@ import com.valuewith.tweaver.auth.dto.AuthDto.EmailInput;
 import com.valuewith.tweaver.auth.dto.AuthDto.SignUpForm;
 import com.valuewith.tweaver.auth.dto.AuthDto.VerificationForm;
 import com.valuewith.tweaver.auth.service.AuthService;
+import com.valuewith.tweaver.commons.security.TokenService;
+import com.valuewith.tweaver.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,10 +21,12 @@ import org.springframework.web.multipart.MultipartFile;
 public class AuthController {
 
   private final AuthService authService;
+  private final TokenService tokenService;
 
   @PostMapping(value = "/signin")
   public ResponseEntity<String> signIn(@RequestBody AuthDto.SignInForm request) {
-    return ResponseEntity.ok(authService.authenticate(request));
+    Member member = authService.authenticate(request);
+    return ResponseEntity.ok(tokenService.createToken(member.getEmail()));
   }
 
   @PostMapping(value = "/signup")

--- a/src/main/java/com/valuewith/tweaver/auth/dto/AuthDto.java
+++ b/src/main/java/com/valuewith/tweaver/auth/dto/AuthDto.java
@@ -1,14 +1,17 @@
 package com.valuewith.tweaver.auth.dto;
 
 import com.valuewith.tweaver.member.entity.Member;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 public class AuthDto {
 
-  // TODO: 로그인
+  @Data
+  @NoArgsConstructor
+  public static class SignInForm {
+    private String email;
+    private String password;
+  }
 
   @Data
   @NoArgsConstructor

--- a/src/main/java/com/valuewith/tweaver/auth/service/AuthService.java
+++ b/src/main/java/com/valuewith/tweaver/auth/service/AuthService.java
@@ -3,7 +3,6 @@ package com.valuewith.tweaver.auth.service;
 import com.valuewith.tweaver.auth.dto.AuthDto;
 import com.valuewith.tweaver.auth.dto.AuthDto.SignInForm;
 import com.valuewith.tweaver.commons.redis.RedisUtilService;
-import com.valuewith.tweaver.commons.security.TokenService;
 import com.valuewith.tweaver.constants.ImageType;
 import com.valuewith.tweaver.defaultImage.entity.DefaultImage;
 import com.valuewith.tweaver.defaultImage.repository.DefaultImageRepository;
@@ -12,6 +11,9 @@ import com.valuewith.tweaver.member.entity.Member;
 import com.valuewith.tweaver.member.repository.MemberRepository;
 import java.util.Locale;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,7 +21,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
-public class AuthService {
+public class AuthService implements UserDetailsService {
 
   private final PasswordEncoder passwordEncoder;
   private final MemberRepository memberRepository;
@@ -27,9 +29,14 @@ public class AuthService {
   private final EmailService emailService;
   private final RedisUtilService redisUtilService;
   private final ImageService imageService;
-  private final TokenService tokenService;
 
-  public String authenticate(SignInForm request) {
+  @Override
+  public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+    return this.memberRepository.findByEmail(email)
+        .orElseThrow(() -> new UsernameNotFoundException("이메일을 찾을 수 없습니다. -> " + email));
+  }
+
+  public Member authenticate(SignInForm request) {
     /**
      * TODO: 커스텀 Exception 예정
      * 1. 이메일 확인
@@ -46,7 +53,7 @@ public class AuthService {
     }
 
     // 3. 토큰 발행
-    return tokenService.generateToken(member.getEmail());
+    return member;
   }
 
   @Transactional

--- a/src/main/java/com/valuewith/tweaver/auth/service/AuthService.java
+++ b/src/main/java/com/valuewith/tweaver/auth/service/AuthService.java
@@ -1,11 +1,14 @@
 package com.valuewith.tweaver.auth.service;
 
 import com.valuewith.tweaver.auth.dto.AuthDto;
+import com.valuewith.tweaver.auth.dto.AuthDto.SignInForm;
 import com.valuewith.tweaver.commons.redis.RedisUtilService;
+import com.valuewith.tweaver.commons.security.TokenService;
 import com.valuewith.tweaver.constants.ImageType;
 import com.valuewith.tweaver.defaultImage.entity.DefaultImage;
 import com.valuewith.tweaver.defaultImage.repository.DefaultImageRepository;
 import com.valuewith.tweaver.defaultImage.service.ImageService;
+import com.valuewith.tweaver.member.entity.Member;
 import com.valuewith.tweaver.member.repository.MemberRepository;
 import java.util.Locale;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +27,27 @@ public class AuthService {
   private final EmailService emailService;
   private final RedisUtilService redisUtilService;
   private final ImageService imageService;
+  private final TokenService tokenService;
+
+  public String authenticate(SignInForm request) {
+    /**
+     * TODO: 커스텀 Exception 예정
+     * 1. 이메일 확인
+     * 2. 비밀번호 확인
+     */
+
+    // 1. 이메일 확인
+    Member member = memberRepository.findByEmail(request.getEmail())
+        .orElseThrow(() -> new RuntimeException("해당 유저를 찾을 수 없습니다."));
+
+    // 2. 비밀번호 확인
+    if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
+      throw new RuntimeException("비밀번호가 다릅니다.");
+    }
+
+    // 3. 토큰 발행
+    return tokenService.generateToken(member.getEmail());
+  }
 
   @Transactional
   public void signUp(AuthDto.SignUpForm form, MultipartFile file) {

--- a/src/main/java/com/valuewith/tweaver/commons/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/valuewith/tweaver/commons/security/JwtAuthenticationFilter.java
@@ -1,0 +1,52 @@
+package com.valuewith.tweaver.commons.security;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  public static final String TOKEN_HEADER = "Authorization";
+  public static final String TOKEN_PREFIX = "Bearer ";
+
+  private final TokenService tokenService;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    String token = resolveTokenFromRequest(request);
+
+    // 토큰이 올바르다면 인증 정보를 Context에 저장하는 과정이 추가
+    if (StringUtils.hasText(token) && tokenService.isValidToken(token)) {
+      Authentication auth = tokenService.getAuthentication(token);
+      SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  /**
+   * 클라이언트에서는 로그인 이후 request headers에 Authorization: Bearer {token} 값이 추가되어야 합니다.
+   */
+  private String resolveTokenFromRequest(HttpServletRequest request) {
+    String token = request.getHeader(TOKEN_HEADER);
+
+    // 토큰에서 "Bearer "를 없엔 뒤 토큰 값만 추출
+    if (!ObjectUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)) {
+      return token.substring(TOKEN_PREFIX.length());
+    }
+
+    return null;
+  }
+}

--- a/src/main/java/com/valuewith/tweaver/commons/security/TokenService.java
+++ b/src/main/java/com/valuewith/tweaver/commons/security/TokenService.java
@@ -1,5 +1,6 @@
 package com.valuewith.tweaver.commons.security;
 
+import com.valuewith.tweaver.auth.service.AuthService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -7,6 +8,9 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -20,10 +24,12 @@ public class TokenService {
   @Value("${jwt-secret-key}")
   private String secretKey;
 
+  private final AuthService authService;
+
   /**
    * 토큰을 생성합니다. email값을 포함한
    */
-  public String generateToken(String email) {
+  public String createToken(String email) {
     Claims claims = Jwts.claims().setSubject(email);
     Date now = new Date();
     Date expiredDate = new Date(now.getTime() + TOKEN_VALID_TIME);
@@ -32,8 +38,15 @@ public class TokenService {
         .setClaims(claims)
         .setIssuedAt(now)
         .setExpiration(expiredDate)
-        .signWith(SignatureAlgorithm.HS512, this.secretKey)
+        .signWith(SignatureAlgorithm.HS512, this.secretKey)  // HMAC 기반 인증
         .compact();
+  }
+
+  // 토큰의 인증정보를 가져옵니다.
+  public Authentication getAuthentication(String jwt) {
+    UserDetails memberDetail = authService.loadUserByUsername(getMemberEmail(jwt));
+    return new UsernamePasswordAuthenticationToken(
+        memberDetail, "", memberDetail.getAuthorities());
   }
 
   public String getMemberEmail(String token) {

--- a/src/main/java/com/valuewith/tweaver/commons/security/TokenService.java
+++ b/src/main/java/com/valuewith/tweaver/commons/security/TokenService.java
@@ -1,0 +1,58 @@
+package com.valuewith.tweaver.commons.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@RequiredArgsConstructor
+public class TokenService {
+
+  // 토큰 유효시간은 1시간입니다.
+  private static final Long TOKEN_VALID_TIME = 1000L * 60L * 60L;
+
+  @Value("${jwt-secret-key}")
+  private String secretKey;
+
+  /**
+   * 토큰을 생성합니다. email값을 포함한
+   */
+  public String generateToken(String email) {
+    Claims claims = Jwts.claims().setSubject(email);
+    Date now = new Date();
+    Date expiredDate = new Date(now.getTime() + TOKEN_VALID_TIME);
+
+    return Jwts.builder()
+        .setClaims(claims)
+        .setIssuedAt(now)
+        .setExpiration(expiredDate)
+        .signWith(SignatureAlgorithm.HS512, this.secretKey)
+        .compact();
+  }
+
+  public String getMemberEmail(String token) {
+    return this.parseClaims(token).getSubject();
+  }
+
+  public Boolean isValidToken(String token) {
+    if (!StringUtils.hasText(token)) {
+      return Boolean.FALSE;
+    }
+    Claims claims = parseClaims(token);
+    return claims.getExpiration().after(new Date());
+  }
+
+  private Claims parseClaims(String token) {
+    try {
+      return Jwts.parser().setSigningKey(this.secretKey).parseClaimsJws(token).getBody();
+    } catch (ExpiredJwtException e) {
+      return e.getClaims();
+    }
+  }
+}

--- a/src/main/java/com/valuewith/tweaver/config/SecurityConfig.java
+++ b/src/main/java/com/valuewith/tweaver/config/SecurityConfig.java
@@ -1,15 +1,21 @@
 package com.valuewith.tweaver.config;
 
+import com.valuewith.tweaver.commons.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @RequiredArgsConstructor
+@EnableWebSecurity
 public class SecurityConfig {
+
+  private final JwtAuthenticationFilter authenticationFilter;
 
   /**
    * swagger, h2-console 접근을 위한 설정입니다.
@@ -24,9 +30,12 @@ public class SecurityConfig {
             // 허용 URL
             "/v2/api-docs", "/v3/api-docs", "/v3/api-docs/**", "/swagger-resources",
             "/swagger-resources/**", "/configuration/ui", "/configuration/security", "/swagger-ui/**",
-            "/webjars/**", "/swagger-ui.html", "/**", "/h2-console")
+            "/webjars/**", "/swagger-ui.html",  "/**", "/h2-console")
         .permitAll().anyRequest().authenticated()
-        .and().headers().frameOptions().disable();
+        .and()
+        .headers().frameOptions().disable()
+        .and()
+        .addFilterBefore(this.authenticationFilter, UsernamePasswordAuthenticationFilter.class);
     return http.build();
   }
 

--- a/src/main/java/com/valuewith/tweaver/member/entity/Member.java
+++ b/src/main/java/com/valuewith/tweaver/member/entity/Member.java
@@ -1,12 +1,15 @@
 package com.valuewith.tweaver.member.entity;
 
 import com.valuewith.tweaver.auditing.BaseEntity;
+import java.util.Collection;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 @Entity
 @Table(name = "MEMBER")
@@ -15,7 +18,7 @@ import javax.validation.constraints.NotNull;
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE MEMBER SET IS_DELETED = 1 WHERE MEMBER_ID = ?")
-public class Member extends BaseEntity {
+public class Member extends BaseEntity implements UserDetails {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long memberId;
@@ -41,4 +44,38 @@ public class Member extends BaseEntity {
 
   @NotNull
   private Boolean isSocial;
+
+  /**
+   * 스프링 시큐리티에서 제공하는 기본 디테일입니다.
+   * 본 멤버에서는 로그인이후
+   */
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return null;
+  }
+
+  @Override
+  public String getUsername() {
+    return this.email;
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return true;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
 }

--- a/src/main/java/com/valuewith/tweaver/member/repository/MemberRepository.java
+++ b/src/main/java/com/valuewith/tweaver/member/repository/MemberRepository.java
@@ -1,9 +1,11 @@
 package com.valuewith.tweaver.member.repository;
 
 import com.valuewith.tweaver.member.entity.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
   Boolean existsByEmail(String email);
+  Optional<Member> findByEmail(String email);
 
 }

--- a/src/test/java/com/valuewith/tweaver/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/valuewith/tweaver/auth/service/AuthServiceTest.java
@@ -2,12 +2,14 @@ package com.valuewith.tweaver.auth.service;
 
 import com.valuewith.tweaver.defaultImage.service.ImageService;
 import com.valuewith.tweaver.member.repository.MemberRepository;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
+import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
+@AutoConfigureMockMvc
 class AuthServiceTest {
 
   static {
@@ -21,12 +23,14 @@ class AuthServiceTest {
   @Autowired
   ImageService imageService;
 
-  @Test
-  @DisplayName("회원가입 성공 테스트")
-  void signup_test() throws Exception {
-    // given
-    // when
-    // then
-  }
+  @Autowired
+  MockMvc mockMvc;
+  @Autowired
+  Environment env;
+
+  /**
+   * TODO: 회원가입 테스트, 로그인 테스트
+   * 현재 UnsatisfiedDependencyException 해결중입니다.
+    */
 
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 로그인 성공시 토큰이 반환됩니다.
- 토큰은 클라이언트에서 요청값 headers에 Authorization에 넣어서 사용합니다.
- 토큰의 유효시간은 1시간입니다.
    - 1시간 이후에는 계속 로그인을 해줘야 합니다.
- 커스텀 예외처리가 되어있지 않습니다.

**TO-BE**
- 추후 토큰값에 여러가지 정보를 요구할 수 있습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트: Swagger, Postman 테스트 확인했습니다.
    - 로그인 성공: 토큰값 반환
    - 로그인 실패: 500 서버 에러 반환