### PR TITLE
[033-DTO-ISDELETED-FIX] 그룹 상세보기 dto 수정 및 엔티티 소프트 삭제 조회 안되게 설정

### DIFF
--- a/src/main/java/com/valuewith/tweaver/alert/entity/Alert.java
+++ b/src/main/java/com/valuewith/tweaver/alert/entity/Alert.java
@@ -14,6 +14,7 @@ import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
 
 import javax.persistence.*;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "ALERT")
@@ -22,6 +23,7 @@ import javax.persistence.*;
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE alert SET IS_DELETED = 1 WHERE ALERT_ID = ?")
+@Where(clause = "IS_DELETED = 0")
 public class Alert extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/valuewith/tweaver/auditing/BaseEntity.java
+++ b/src/main/java/com/valuewith/tweaver/auditing/BaseEntity.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.Where;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;

--- a/src/main/java/com/valuewith/tweaver/chat/entity/ChatRoom.java
+++ b/src/main/java/com/valuewith/tweaver/chat/entity/ChatRoom.java
@@ -16,6 +16,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "CHAT_ROOM")
@@ -24,6 +25,7 @@ import org.hibernate.annotations.SQLDelete;
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE chat_room SET IS_DELETED = 1 WHERE CHAT_ROOM_ID = ?")
+@Where(clause = "IS_DELETED = 0")
 public class ChatRoom extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/valuewith/tweaver/config/SecurityConfig.java
+++ b/src/main/java/com/valuewith/tweaver/config/SecurityConfig.java
@@ -45,7 +45,11 @@ public class SecurityConfig {
     http
         .cors(cors -> cors.configurationSource(request -> {
           CorsConfiguration config = new CorsConfiguration();
-          config.setAllowedOrigins(Arrays.asList("https://tweaver.vercel.app"));
+          config.setAllowedOrigins(Arrays.asList(
+              "https://tweaver.vercel.app",
+              "http://localhost:5173",
+              "http://127.0.0.1:5173"
+              ));
           config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
           config.setAllowedHeaders(Arrays.asList("*"));
           config.setAllowCredentials(true);

--- a/src/main/java/com/valuewith/tweaver/group/entity/TripGroup.java
+++ b/src/main/java/com/valuewith/tweaver/group/entity/TripGroup.java
@@ -23,6 +23,7 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.Formula;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "TRIP_GROUP")
@@ -31,6 +32,7 @@ import org.hibernate.annotations.SQLDelete;
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE trip_group SET IS_DELETED = 1 WHERE TRIP_GROUP_ID = ?")
+@Where(clause = "IS_DELETED = 0")
 public class TripGroup extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/valuewith/tweaver/groupMember/dto/GroupMemberDetailResponseDto.java
+++ b/src/main/java/com/valuewith/tweaver/groupMember/dto/GroupMemberDetailResponseDto.java
@@ -1,5 +1,6 @@
 package com.valuewith.tweaver.groupMember.dto;
 
+import com.valuewith.tweaver.constants.ApprovedStatus;
 import com.valuewith.tweaver.groupMember.entity.GroupMember;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,6 +17,7 @@ public class GroupMemberDetailResponseDto {
     private Integer groupMemberAge;
     private String groupMemberGender;
     private String groupMemberProfileUrl;
+    private String groupMemberStatus;
     public static GroupMemberDetailResponseDto from(
         GroupMember groupMember
     ) {
@@ -26,6 +28,7 @@ public class GroupMemberDetailResponseDto {
             .groupMemberAge(groupMember.getMember().getAge())
             .groupMemberGender(groupMember.getMember().getGender())
             .groupMemberProfileUrl(groupMember.getMember().getProfileUrl())
+            .groupMemberStatus(groupMember.getApprovedStatus().name().toLowerCase())
             .build();
     }
 

--- a/src/main/java/com/valuewith/tweaver/groupMember/entity/GroupMember.java
+++ b/src/main/java/com/valuewith/tweaver/groupMember/entity/GroupMember.java
@@ -23,6 +23,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "GROUP_MEMBER")
@@ -31,6 +32,7 @@ import org.hibernate.annotations.SQLDelete;
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE group_member SET IS_DELETED = 1 WHERE GROUP_MEMBER_ID = ?")
+@Where(clause = "IS_DELETED = 0")
 public class GroupMember extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/valuewith/tweaver/member/entity/Member.java
+++ b/src/main/java/com/valuewith/tweaver/member/entity/Member.java
@@ -23,6 +23,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "MEMBER")
@@ -31,6 +32,7 @@ import org.hibernate.annotations.SQLDelete;
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE member SET IS_DELETED = 1 WHERE MEMBER_ID = ?")
+@Where(clause = "IS_DELETED = 0")
 public class Member extends BaseEntity {
 
   @Id

--- a/src/main/java/com/valuewith/tweaver/message/entity/Message.java
+++ b/src/main/java/com/valuewith/tweaver/message/entity/Message.java
@@ -18,6 +18,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "MESSAGE")
@@ -26,6 +27,7 @@ import org.hibernate.annotations.SQLDelete;
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE message SET IS_DELETED = 1 WHERE MESSAGE_ID = ?")
+@Where(clause = "IS_DELETED = 0")
 public class Message extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/valuewith/tweaver/place/entity/Place.java
+++ b/src/main/java/com/valuewith/tweaver/place/entity/Place.java
@@ -11,6 +11,7 @@ import org.hibernate.annotations.SQLDelete;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+import org.hibernate.annotations.Where;
 import reactor.util.annotation.Nullable;
 
 @Entity
@@ -20,6 +21,7 @@ import reactor.util.annotation.Nullable;
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE place SET IS_DELETED = 1 WHERE PLACE_ID = ?")
+@Where(clause = "IS_DELETED = 0")
 public class Place extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 그룹 상세보기 dto 그룹멤버 상태 소문자 영어로 반환 추가
- 엔티티 관련 @Where 어노테이션 적용으로 소프트 삭제된 데이터 조회 안되게 하기

**TO-BE**
- 토큰 배어럴 파싱 후 email 보내기
- 회원정보 수정 API(회원 조회 / 회원 정보 수정)
- 에러처리 멤버, 그룹, 그룹멤버, 장소 진행



### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 