### PR TITLE
refactor: [035-ADD-AUTH-EXCEPTION] 인증관련 Custom Exception 추가 및 Token 기능 수정

### DIFF
--- a/src/main/java/com/valuewith/tweaver/auth/dto/AuthDto.java
+++ b/src/main/java/com/valuewith/tweaver/auth/dto/AuthDto.java
@@ -36,7 +36,6 @@ public class AuthDto {
     private String gender;
     private Integer age;
 
-    // TODO: to 메소드 사용법 변경
     public Member setProfileUrl(String profileUrl) {
       return Member.builder()
           .nickName(this.nickname)

--- a/src/main/java/com/valuewith/tweaver/auth/service/AuthService.java
+++ b/src/main/java/com/valuewith/tweaver/auth/service/AuthService.java
@@ -1,21 +1,26 @@
 package com.valuewith.tweaver.auth.service;
 
+import static com.valuewith.tweaver.constants.ErrorCode.*;
+
 import com.valuewith.tweaver.auth.dto.AuthDto;
 import com.valuewith.tweaver.auth.dto.AuthDto.SignInForm;
 import com.valuewith.tweaver.auth.dto.AuthDto.TokensAndMemberId;
 import com.valuewith.tweaver.auth.dto.LoginMemberIdDto;
 import com.valuewith.tweaver.commons.redis.RedisUtilService;
 import com.valuewith.tweaver.commons.security.service.TokenService;
+import com.valuewith.tweaver.constants.ErrorCode;
 import com.valuewith.tweaver.constants.ImageType;
 import com.valuewith.tweaver.defaultImage.entity.DefaultImage;
 import com.valuewith.tweaver.defaultImage.repository.DefaultImageRepository;
 import com.valuewith.tweaver.defaultImage.service.ImageService;
+import com.valuewith.tweaver.exception.CustomException;
 import com.valuewith.tweaver.member.entity.Member;
 import com.valuewith.tweaver.member.repository.MemberRepository;
 import java.util.Locale;
 import java.util.Optional;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,26 +39,6 @@ public class AuthService {
   private final TokenService tokenService;
 
 
-  public Member authenticate(SignInForm request) {
-    /**
-     * TODO: 커스텀 Exception 예정
-     * 1. 이메일 확인
-     * 2. 비밀번호 확인
-     */
-
-    // 1. 이메일 확인
-    Member member = memberRepository.findByEmail(request.getEmail())
-        .orElseThrow(() -> new RuntimeException("해당 유저를 찾을 수 없습니다."));
-
-    // 2. 비밀번호 확인
-    if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
-      throw new RuntimeException("비밀번호가 다릅니다.");
-    }
-
-    // 3. 토큰 발행
-    return member;
-  }
-
   @Transactional
   public void signUp(AuthDto.SignUpForm form, MultipartFile file) {
     String profileUrl = "";
@@ -62,9 +47,14 @@ public class AuthService {
       profileUrl = imageService.uploadImageAndGetUrl(file, ImageType.MEMBER);
     } else {
       // 사진을 못받은 경우 기본 이미지 등록
-      // TODO: 기본 프로필 이미지 업로드 되면 다시 확인 (23년 11월 16일 1차 작업중)
-      DefaultImage defaultImg = defaultImageRepository.findByImageName("멤버");
-      profileUrl = defaultImg.getDefaultImageUrl();
+      // TODO: 기본 프로필 이미지 업로드 되면 다시 확인 - eod940(23.11.16)
+      // TODO: 기본 프로필 이미지 업로드시 Custom Exception 제거 - eod940(23.11.20)
+      try {
+        DefaultImage defaultImg = defaultImageRepository.findByImageName("멤버");
+        profileUrl = defaultImg.getDefaultImageUrl();
+      } catch (Exception e) {
+        throw new CustomException(FAILURE_GETTING_PROFILE_IMG);
+      }
     }
     // 비밀번호 암호화
     form.setPassword(this.passwordEncoder.encode(form.getPassword()));
@@ -75,8 +65,7 @@ public class AuthService {
   public void sendEmailVerification(AuthDto.EmailInput input) {
     String receiver = input.getEmail();
     if (isEmailExist(receiver)) {
-      // TODO: 커스텀 Exception 적용
-      throw new RuntimeException("이미 사용중인 이메일 입니다.");
+      throw new CustomException(DUPLICATE_EMAIL);
     }
     emailService.sendCodeForValid(receiver);
   }
@@ -85,12 +74,10 @@ public class AuthService {
     String emailCode = form.getCode();
     String savedCode = redisUtilService.getData(form.getEmail());
     if (savedCode.isEmpty()) {
-      // TODO: 커스텀 Exception 적용
-      throw new RuntimeException("만료된 코드 입니다.");
+      throw new CustomException(INVALID_CODE);
     }
     if (!emailCode.equals(savedCode)) {
-      // TODO: 커스텀 Exception 적용
-      throw new RuntimeException("인증코드가 다릅니다.");
+      throw new CustomException(INCORRECT_CODE);
     }
     return Boolean.TRUE;
   }

--- a/src/main/java/com/valuewith/tweaver/auth/service/CustomMemberDetailService.java
+++ b/src/main/java/com/valuewith/tweaver/auth/service/CustomMemberDetailService.java
@@ -23,6 +23,7 @@ public class CustomMemberDetailService implements UserDetailsService {
 
     Provider memberProvider = member.getProvider();
     if (memberProvider != Provider.NORMAL) {
+      //TODO: 소셜로그인 Provider 안맞을 경우 생기는 익셉션 추가
       throw new RuntimeException(memberProvider + " 소셜 로그인 계정입니다.");
     }
     return new PrincipalDetails(member);

--- a/src/main/java/com/valuewith/tweaver/auth/service/EmailService.java
+++ b/src/main/java/com/valuewith/tweaver/auth/service/EmailService.java
@@ -1,8 +1,12 @@
 package com.valuewith.tweaver.auth.service;
 
+import static com.valuewith.tweaver.constants.ErrorCode.*;
+
 import com.valuewith.tweaver.auth.client.MailgunClient;
 import com.valuewith.tweaver.auth.client.mailgun.SendEmailForm;
 import com.valuewith.tweaver.commons.redis.RedisUtilService;
+import com.valuewith.tweaver.constants.ErrorCode;
+import com.valuewith.tweaver.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.stereotype.Service;
@@ -15,7 +19,11 @@ public class EmailService {
   private final RedisUtilService redisUtilService;
 
   public String sendMail(SendEmailForm sendForm) {
-    return mailgunClient.sendEmail(sendForm).getBody();
+    try {
+      return mailgunClient.sendEmail(sendForm).getBody();
+    } catch (Exception e) {
+      throw new CustomException(FAILURE_SENDING_EMAIL);
+    }
   }
 
   public void sendCodeForValid(String memberEmail) {

--- a/src/main/java/com/valuewith/tweaver/commons/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/valuewith/tweaver/commons/security/JwtAuthenticationFilter.java
@@ -41,8 +41,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     if (request.getRequestURI().equals("/auth/signin")
         && StringUtils.hasText(token)
         && tokenService.isValidToken(token)) {
-//      Authentication auth = tokenService.getAuthentication(token);
-//      SecurityContextHolder.getContext().setAuthentication(auth);
       filterChain.doFilter(request, response);
       return;
     }

--- a/src/main/java/com/valuewith/tweaver/constants/ErrorCode.java
+++ b/src/main/java/com/valuewith/tweaver/constants/ErrorCode.java
@@ -11,7 +11,21 @@ public enum ErrorCode {
     INVALID_FILE_MEDIA_TYPE("JPG, JPEG, PNG 형식만 가능합니다.", HttpStatus.UNSUPPORTED_MEDIA_TYPE),
     S3_IMAGE_NOT_FOUND("이미지 저장소에서 파일을 찾을 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     URL_IS_EMPTY("제공된 URL이 없습니다.", HttpStatus.BAD_REQUEST),
-    LOCATION_NAME_NOT_FOUNT("지역 이름은 필수입니다.", HttpStatus.BAD_REQUEST)
+    LOCATION_NAME_NOT_FOUNT("지역 이름은 필수입니다.", HttpStatus.BAD_REQUEST),
+
+    // ======== Auth ========
+    // 401
+    INVALID_CODE("만료된 코드 입니다.", HttpStatus.UNAUTHORIZED),
+    INCORRECT_CODE("인증코드가 다릅니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_JWT("잘못된 인증 정보입니다.", HttpStatus.UNAUTHORIZED),
+    // 404
+    MEMBER_NOT_FOUND("회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    // 409
+    DUPLICATE_EMAIL("중복된 이메일입니다.", HttpStatus.CONFLICT),
+    // 502
+    FAILURE_SENDING_EMAIL("이메일 전송에 실패하였습니다.", HttpStatus.BAD_GATEWAY),
+    FAILURE_GETTING_PROFILE_IMG("프로필 이미지가 없습니다.", HttpStatus.BAD_GATEWAY),
+
     ;
 
 

--- a/src/main/java/com/valuewith/tweaver/exception/CustomException.java
+++ b/src/main/java/com/valuewith/tweaver/exception/CustomException.java
@@ -1,0 +1,19 @@
+package com.valuewith.tweaver.exception;
+
+import com.valuewith.tweaver.constants.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+  private final String message;
+  private final HttpStatus httpStatus;
+
+  public CustomException(ErrorCode errorCode) {
+    this.errorCode = errorCode;
+    this.message = errorCode.getDescription();
+    this.httpStatus = errorCode.getHttpStatus();
+  }
+}

--- a/src/main/java/com/valuewith/tweaver/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/valuewith/tweaver/exception/GlobalExceptionHandler.java
@@ -16,7 +16,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(NoFileProvidedException.class)
-    public ResponseEntity<ErrorResponseDto> handleNoFileProvidedException(NoFileProvidedException e) {
+    public ResponseEntity<ErrorResponseDto> handleNoFileProvidedException(
+        NoFileProvidedException e) {
         ErrorResponseDto responseDto = ErrorResponseDto.from(e.getErrorCode());
         return ResponseEntity
             .status(e.getHttpStatus())
@@ -24,7 +25,8 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(InvalidFileMediaTypeException.class)
-    public ResponseEntity<ErrorResponseDto> handleInvalidFileMediaTypeException(InvalidFileMediaTypeException e) {
+    public ResponseEntity<ErrorResponseDto> handleInvalidFileMediaTypeException(
+        InvalidFileMediaTypeException e) {
         ErrorResponseDto responseDto = ErrorResponseDto.from(e.getErrorCode());
         return ResponseEntity
             .status(e.getHttpStatus())
@@ -32,7 +34,8 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(S3ImageNotFoundException.class)
-    public ResponseEntity<ErrorResponseDto> handleS3ImageNotFoundException(S3ImageNotFoundException e) {
+    public ResponseEntity<ErrorResponseDto> handleS3ImageNotFoundException(
+        S3ImageNotFoundException e) {
         ErrorResponseDto responseDto = ErrorResponseDto.from(e.getErrorCode());
         return ResponseEntity
             .status(e.getHttpStatus())
@@ -48,7 +51,17 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(LocationNameEmptyException.class)
-    public ResponseEntity<ErrorResponseDto> handleLocationNameEmptyException(LocationNameEmptyException e) {
+    public ResponseEntity<ErrorResponseDto> handleLocationNameEmptyException(
+        LocationNameEmptyException e) {
+        ErrorResponseDto responseDto = ErrorResponseDto.from(e.getErrorCode());
+        return ResponseEntity
+            .status(e.getHttpStatus())
+            .body(responseDto);
+    }
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponseDto> handleCustomException(
+        CustomException e) {
         ErrorResponseDto responseDto = ErrorResponseDto.from(e.getErrorCode());
         return ResponseEntity
             .status(e.getHttpStatus())

--- a/src/main/java/com/valuewith/tweaver/member/service/MemberService.java
+++ b/src/main/java/com/valuewith/tweaver/member/service/MemberService.java
@@ -1,5 +1,9 @@
 package com.valuewith.tweaver.member.service;
 
+import static com.valuewith.tweaver.constants.ErrorCode.*;
+
+import com.valuewith.tweaver.constants.ErrorCode;
+import com.valuewith.tweaver.exception.CustomException;
 import com.valuewith.tweaver.member.entity.Member;
 import com.valuewith.tweaver.member.repository.MemberRepository;
 import java.util.Optional;
@@ -13,10 +17,12 @@ public class MemberService {
 
   public Member findMemberByEmail(String memberEmail) {
     return memberRepository.findByEmail(memberEmail)
-        .orElseThrow(() -> new RuntimeException("멤버가 존재하지 않습니다."));
+        .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
   }
 
   public Member findMemberByMemberId(Long id) {
-    return memberRepository.findById(id).orElseThrow();
+    return memberRepository.findById(id).orElseThrow(
+        () -> new CustomException(MEMBER_NOT_FOUND)
+    );
   }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
TokenService::getMemberEmail 역할은 `Bearer ` 파싱 없이 순수 토큰값만을 가지고 회원의 email을 반환합니다.
- #74 이후 의도는 토큰이 필요한 모든 controller단에서 HttpServletRequest를 받아 TokenService::parseAccessToken 을 이용하는 것이었습니다.
- 그래서 TokenService::getMemberEmail 부분과 TokenService::parseAccessToken 로직이 동일합니다.

회원 인증관련 부분 에러가 전부 500으로만 처리되었습니다.

**TO-BE**
TokenService::getMemberEmail 호출하시면 `Bearer ` 파싱 후 회원의 email을 반환합니다.
회원 인증관련 부분 에러를 전부 CustomException으로 변경하였습니다.


### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 