### PR TITLE
fix: [FIX-MESSAGE-OAUTH2] 메시지 DB 적용 및 Security 허용 URL 변경

### DIFF
--- a/src/main/java/com/valuewith/tweaver/config/SecurityConfig.java
+++ b/src/main/java/com/valuewith/tweaver/config/SecurityConfig.java
@@ -88,7 +88,8 @@ public class SecurityConfig {
                 "/groups/**",
                 "/images/**",
                 "/member/**",
-                "/member"
+                "/member",
+                "/oauth2/**"
             )
             .permitAll()
             // 회원만 들어갈 수 있는 API는 현재 Security에서 거르지 못합니다.

--- a/src/main/java/com/valuewith/tweaver/message/service/MessageService.java
+++ b/src/main/java/com/valuewith/tweaver/message/service/MessageService.java
@@ -13,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class MessageService {
   private final ChatRoomRepository chatRoomRepository;
   private final MessageRepository messageRepository;


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
메시지 전송시 메시지가 DB에 저장되지 않습니다.
카카오 로그인 호출시 URL이 허용되지 않습니다.

**TO-BE**
메시지 전송시 메시지가 DB에 저장됩니다.
카카오 로그인 호출시 `oauth/**` 접근을 허용합니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 