### PR TITLE
refactor: [036-MESSAGE-REFACTOR] 입장 메시지 로직 변경, 메시지 작성일자 포함한 response 반환

### DIFF
--- a/src/main/java/com/valuewith/tweaver/auth/service/OAuthUserCustomService.java
+++ b/src/main/java/com/valuewith/tweaver/auth/service/OAuthUserCustomService.java
@@ -51,6 +51,7 @@ public class OAuthUserCustomService implements OAuth2UserService<OAuth2UserReque
 
   private Provider getProvider(String registrationId) {
     // 다른 소셜로그인이 있다면 추가해야합니다.
+    // TODO: 허가받지 않은 url 호출시 카카오 로그인이 됩니다. 이부분 수정하면 될 것 같습니다. -eod940
     System.out.println(registrationId + " 로그인 진행중");
     return Provider.KAKAO;
   }

--- a/src/main/java/com/valuewith/tweaver/chat/dto/ChatRoomDto.java
+++ b/src/main/java/com/valuewith/tweaver/chat/dto/ChatRoomDto.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ChatRoomDto {
+public class ChatRoomDto{
   private Long chatRoomId;
   private Long tripGroupId;
   private String title;

--- a/src/main/java/com/valuewith/tweaver/groupMember/repository/GroupMemberRepository.java
+++ b/src/main/java/com/valuewith/tweaver/groupMember/repository/GroupMemberRepository.java
@@ -21,6 +21,4 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long>,
       Long memberId, Long tripGroupId);
 
   Optional<GroupMember> findByGroupMemberId(Long groupMemberId);
-
-  List<GroupMember> findGroupMembersByTripGroup_TripGroupId(Long tripGroupId);
 }

--- a/src/main/java/com/valuewith/tweaver/message/controller/MessageController.java
+++ b/src/main/java/com/valuewith/tweaver/message/controller/MessageController.java
@@ -22,19 +22,6 @@ public class MessageController {
   private final MessageService messageService;
   private final SimpMessageSendingOperations simpMessageSendingOperations;
 
-  @MessageMapping("/message/join/{chatRoomId}/{memberId}")
-  public void enterMember(@DestinationVariable("chatRoomId") Long chatRoomId,
-      @DestinationVariable("memberId") Long memberId) {
-    ChatRoom chatRoom = chatRoomService.findByChatRoomId(chatRoomId);
-    Member sender = memberService.findMemberByMemberId(memberId);
-    String helloMessage =
-        sender.getNickName() + "님이 " + chatRoom.getTripGroup().getName() + "그룹에 참여하셨습니다.";
-
-    MessageDto newMessage = messageService.createMessage(chatRoom, sender, helloMessage);
-
-    simpMessageSendingOperations.convertAndSend("/sub/chat/room/" + chatRoom.getChatRoomId(),
-        newMessage);
-  }
 
   @MessageMapping("/message/{chatRoomId}")
   public void sendMessage(@Payload MessageDto message,

--- a/src/main/java/com/valuewith/tweaver/message/dto/MessageDto.java
+++ b/src/main/java/com/valuewith/tweaver/message/dto/MessageDto.java
@@ -4,6 +4,7 @@ import com.valuewith.tweaver.auditing.BaseEntity;
 import com.valuewith.tweaver.auth.dto.LoginMemberIdDto;
 import com.valuewith.tweaver.member.entity.Member;
 import com.valuewith.tweaver.message.entity.Message;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,12 +17,14 @@ import lombok.NoArgsConstructor;
 public class MessageDto {
   private LoginMemberIdDto memberIdDto;
   private String content;
+  private LocalDateTime created_at;
 
   public static MessageDto from(Message message) {
     Member member = message.getMember();
     return MessageDto.builder()
         .content(message.getContent())
         .memberIdDto(LoginMemberIdDto.from(member))
+        .created_at(message.getCreatedDateTime())
         .build();
   }
 }

--- a/src/main/java/com/valuewith/tweaver/message/service/MessageService.java
+++ b/src/main/java/com/valuewith/tweaver/message/service/MessageService.java
@@ -8,6 +8,7 @@ import com.valuewith.tweaver.message.entity.Message;
 import com.valuewith.tweaver.message.repository.MessageRepository;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +19,7 @@ public class MessageService {
   private final ChatRoomRepository chatRoomRepository;
   private final MessageRepository messageRepository;
 
+  @Transactional
   public void deleteMessage(Long tripGroupId) {
     ChatRoom chatRoom = chatRoomRepository.findByTripGroupTripGroupId(tripGroupId)
         .orElseThrow(() -> new RuntimeException("삭제 하려는 메세지의 채팅방이 존재하지 않습니다."));

--- a/src/test/java/com/valuewith/tweaver/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/valuewith/tweaver/auth/controller/AuthControllerTest.java
@@ -42,7 +42,6 @@ class AuthControllerTest {
   @Autowired
   MockMvc mockMvc;
 
-  ObjectMapper objectMapper;
   MockMultipartFile imgfile = new MockMultipartFile(
       "image", "test.jpeg", "image/jpeg", "image_content".getBytes());
   AuthDto.SignUpForm signUpForm = SignUpForm.builder()

--- a/src/test/java/com/valuewith/tweaver/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/valuewith/tweaver/chat/controller/ChatRoomControllerTest.java
@@ -1,0 +1,98 @@
+package com.valuewith.tweaver.chat.controller;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.valuewith.tweaver.chat.service.ChatRoomService;
+import com.valuewith.tweaver.commons.security.service.TokenService;
+import com.valuewith.tweaver.constants.Provider;
+import com.valuewith.tweaver.exception.GlobalExceptionHandler;
+import com.valuewith.tweaver.member.entity.Member;
+import com.valuewith.tweaver.member.repository.MemberRepository;
+import com.valuewith.tweaver.message.repository.MessageRepository;
+import com.valuewith.tweaver.message.service.MessageService;
+import com.valuewith.tweaver.mock.WithCustomMockMember;
+import java.security.Principal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ChatRoomController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureMockMvc
+class ChatRoomControllerTest {
+
+  @MockBean
+  ChatRoomController chatRoomController;
+  @MockBean
+  GlobalExceptionHandler globalExceptionHandler;
+  @MockBean
+  ChatRoomService chatRoomService;
+  @MockBean
+  TokenService tokenService;
+  @MockBean
+  MemberRepository memberRepository;
+  @MockBean
+  MessageService messageService;
+  @MockBean
+  MessageRepository messageRepository;
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    Member member = Member.builder()
+        .memberId(1L)
+        .email("a@a.a")
+        .nickName("a")
+        .age(11)
+        .gender("male")
+        .profileUrl("http://a")
+        .provider(Provider.NORMAL)
+        .build();
+
+    memberRepository.save(member);
+  }
+
+  @Test
+  @WithMockUser
+  @DisplayName("채팅룸 불러오기 호출 성공: 인증된 사용자")
+  void pass_charRoom_test() throws Exception {
+    /*
+    로그인 된 사용자가 호출하면 성공
+     */
+    mockMvc.perform(get("/chat/room")
+            .accept(MediaType.APPLICATION_JSON)
+            .with(csrf()))
+        .andDo(print())
+        .andExpect(status().isOk());
+
+  }
+
+  @Test
+  @DisplayName("채팅룸 불러오기 호출 실패: 스프링 시큐리티 작동")
+  void fail_charRoom_test() throws Exception {
+    /*
+    로그인을 안하면 스프링 시큐리티는 로그인 페이지로 redirection 시킨다.
+    컨트롤러 내부 작동은 유닛 테스트를 진행해봐야 할 것 같습니다. - eod940
+     */
+    mockMvc.perform(get("/chat/room"))
+        .andDo(print())
+        .andExpect(status().is3xxRedirection());
+  }
+}

--- a/src/test/java/com/valuewith/tweaver/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/valuewith/tweaver/chat/controller/ChatRoomControllerTest.java
@@ -1,9 +1,7 @@
 package com.valuewith.tweaver.chat.controller;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -15,19 +13,15 @@ import com.valuewith.tweaver.member.entity.Member;
 import com.valuewith.tweaver.member.repository.MemberRepository;
 import com.valuewith.tweaver.message.repository.MessageRepository;
 import com.valuewith.tweaver.message.service.MessageService;
-import com.valuewith.tweaver.mock.WithCustomMockMember;
-import java.security.Principal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 

--- a/src/test/java/com/valuewith/tweaver/groupMember/service/GroupMemberApplicationServiceTest.java
+++ b/src/test/java/com/valuewith/tweaver/groupMember/service/GroupMemberApplicationServiceTest.java
@@ -1,0 +1,110 @@
+package com.valuewith.tweaver.groupMember.service;
+
+import static com.valuewith.tweaver.constants.ApprovedStatus.PENDING;
+import static com.valuewith.tweaver.constants.GroupStatus.OPEN;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+
+import com.valuewith.tweaver.chat.entity.ChatRoom;
+import com.valuewith.tweaver.chat.repository.ChatRoomRepository;
+import com.valuewith.tweaver.constants.Provider;
+import com.valuewith.tweaver.group.entity.TripGroup;
+import com.valuewith.tweaver.group.repository.TripGroupRepository;
+import com.valuewith.tweaver.groupMember.entity.GroupMember;
+import com.valuewith.tweaver.groupMember.repository.GroupMemberRepository;
+import com.valuewith.tweaver.member.entity.Member;
+import com.valuewith.tweaver.member.service.MemberService;
+import com.valuewith.tweaver.message.dto.MessageDto;
+import com.valuewith.tweaver.message.entity.Message;
+import com.valuewith.tweaver.message.repository.MessageRepository;
+import com.valuewith.tweaver.message.service.MessageService;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.AdditionalAnswers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class GroupMemberApplicationServiceTest {
+
+  @InjectMocks
+  private GroupMemberApplicationService groupMemberApplicationService;
+  @InjectMocks
+  private MessageService messageService;
+
+  @Mock
+  private TripGroupRepository tripGroupRepository;
+  @Mock
+  private GroupMemberRepository groupMemberRepository;
+  @Mock
+  private ChatRoomRepository chatRoomRepository;
+  @Mock
+  private MemberService memberService;
+  @Mock
+  private MessageRepository messageRepository;
+  @Mock
+  private ApplicationEventPublisher applicationEventPublisher;
+
+  Member alice = Member.builder()
+      .memberId(1L)
+      .email("alice@a.a")
+      .password("a")
+      .nickName("alice")
+      .age(21)
+      .gender("male")
+      .profileUrl("http://a")
+      .provider(Provider.NORMAL)
+      .refreshToken("a")
+      .build();
+
+  Member bob = Member.builder()
+      .memberId(1L)
+      .email("bob@b.b")
+      .password("b")
+      .nickName("bob")
+      .age(12)
+      .gender("female")
+      .profileUrl("http://b")
+      .provider(Provider.NORMAL)
+      .refreshToken("b")
+      .build();
+
+  TripGroup aliceGroup = TripGroup.builder()
+      .tripGroupId(1L)
+      .name("앨리스가 만든 그룹")
+      .content("alice")
+      .maxMemberNumber(4)
+      .currentMemberNumber(1)
+      .tripArea("a")
+      .tripDate(LocalDate.now())
+      .dueDate(LocalDate.MAX)
+      .member(alice)
+      .status(OPEN)
+      .build();
+
+  ChatRoom aliceChatRoom = ChatRoom.builder()
+      .chatRoomId(1L)
+      .tripGroup(aliceGroup)
+      .title("엘리스가 만든 그룹 챗방")
+      .build();
+
+  GroupMember memberBob = GroupMember.builder()
+      .groupMemberId(1L)
+      .approvedStatus(PENDING)
+      .member(bob)
+      .tripGroup(aliceGroup)
+      .build();
+
+  @Test
+  @DisplayName("성공: 그룹 참여 승인시 채팅방 참여 메시지 보내기")
+  void confirm_application() {
+    // TODO: eod940 GitHubGist에 에러나는 테스트가 있습니다. 누군가 제발 도와주세요 -eod940
+  }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
채팅방 조회후 채팅방을 구독하면 입장 메시지가 전송되었습니다.
채팅방 조회시 메시지 작성일자가 포함되지 않은 response를 반환했습니다.

**TO-BE**
그룹 승인시 채팅방에 입장 메시지가 전송됩니다.
채팅방 조회시 메시지 작성일자가 포함된 response를 반환합니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
    - 그룹 승인 서비스 테스트 하다가 너무 막혀서 도움을 요청드려요.... ㅠㅠ
- [x] API 테스트 