### PR TITLE
fix: [039-ALERT/REFACTOR] AlertController의 모든 memberId 가져오는 로직 수정

### DIFF
--- a/src/main/java/com/valuewith/tweaver/alert/controller/AlertController.java
+++ b/src/main/java/com/valuewith/tweaver/alert/controller/AlertController.java
@@ -39,7 +39,6 @@ public class AlertController {
   public ResponseEntity<SseEmitter> subscribe(
       @RequestHeader("Authorization") String token,
       @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId) {
-    //Member member = memberService.findMemberByEmail();
     // 서비스를 통해 생성된 SseEmitter를 반환
     return ResponseEntity.ok(alertService.subscribe(tokenService.getMemberId(token), lastEventId));
   }
@@ -47,11 +46,11 @@ public class AlertController {
   // 내 알림 목록 조회
   @ApiOperation(value = "내 알림목록 조회 API")
   @GetMapping
-  public ResponseEntity<Slice<AlertResponseDto>> alerts(@RequestHeader("Authorization") String token,
+  public ResponseEntity<Slice<AlertResponseDto>> alerts(
+      @RequestHeader("Authorization") String token,
       @PageableDefault(size = 20) Pageable pageable) {
-    Member member = memberService.findMemberByEmail(tokenService.getMemberEmail(token));
 
-    return ResponseEntity.ok(alertService.getAlerts(member.getMemberId(), pageable));
+    return ResponseEntity.ok(alertService.getAlerts(tokenService.getMemberId(token), pageable));
   }
 
   /**
@@ -64,8 +63,7 @@ public class AlertController {
       @PathVariable("alertId") Long alarmId,
       @RequestHeader("Authorization") String token
   ) {
-    Member member = memberService.findMemberByEmail(tokenService.getMemberEmail(token));
-    Long alertCnt = alertService.check(member.getMemberId(), alarmId);
+    Long alertCnt = alertService.check(tokenService.getMemberId(token), alarmId);
     return ResponseEntity.ok(alertCnt);
   }
 
@@ -77,8 +75,7 @@ public class AlertController {
   public ResponseEntity<String> allCheck(
       @RequestHeader("Authorization") String token
   ) {
-    Member member = memberService.findMemberByEmail(tokenService.getMemberEmail(token));
-    alertService.allCheck(member.getMemberId());
+    alertService.allCheck(tokenService.getMemberId(token));
     return ResponseEntity.ok("ok");
   }
 
@@ -92,8 +89,7 @@ public class AlertController {
       @PathVariable("alertId") Long alarmId,
       @RequestHeader("Authorization") String token
   ) {
-    Member member = memberService.findMemberByEmail(tokenService.getMemberEmail(token));
-    Long alertCnt = alertService.delete(member.getMemberId(), alarmId);
+    Long alertCnt = alertService.delete(tokenService.getMemberId(token), alarmId);
     return ResponseEntity.ok(alertCnt);
   }
 

--- a/src/main/java/com/valuewith/tweaver/alert/controller/AlertController.java
+++ b/src/main/java/com/valuewith/tweaver/alert/controller/AlertController.java
@@ -39,9 +39,9 @@ public class AlertController {
   public ResponseEntity<SseEmitter> subscribe(
       @RequestHeader("Authorization") String token,
       @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId) {
-    Member member = memberService.findMemberByEmail(tokenService.getMemberEmail(token));
+    //Member member = memberService.findMemberByEmail();
     // 서비스를 통해 생성된 SseEmitter를 반환
-    return ResponseEntity.ok(alertService.subscribe(member.getMemberId(), lastEventId));
+    return ResponseEntity.ok(alertService.subscribe(tokenService.getMemberId(token), lastEventId));
   }
 
   // 내 알림 목록 조회

--- a/src/main/java/com/valuewith/tweaver/auth/handler/SigninSuccessHandler.java
+++ b/src/main/java/com/valuewith/tweaver/auth/handler/SigninSuccessHandler.java
@@ -34,7 +34,7 @@ public class SigninSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         () -> new UsernameNotFoundException(email + "는(은) 없는 회원입니다."));
     String memberEmail = member.getEmail();
 
-    String accessToken = tokenService.createAccessToken(memberEmail);
+    String accessToken = tokenService.createAccessToken(memberEmail, member.getMemberId());
     String refreshToken = tokenService.createRefreshToken();
 
     // response header에 토큰 추가

--- a/src/main/java/com/valuewith/tweaver/auth/service/AuthService.java
+++ b/src/main/java/com/valuewith/tweaver/auth/service/AuthService.java
@@ -92,7 +92,7 @@ public class AuthService {
       return null;
     }
     String newRefreshToken = reissueRefreshToken(member.get());
-    String newAccessToken = tokenService.createAccessToken(member.get().getEmail());
+    String newAccessToken = tokenService.createAccessToken(member.get().getEmail(), member.get().getMemberId());
 
     tokenService.sendAccessToken(response, newAccessToken);
     tokenService.sendAccessTokenAndRefreshToken(response, newAccessToken, newRefreshToken);

--- a/src/main/java/com/valuewith/tweaver/commons/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/valuewith/tweaver/commons/security/JwtAuthenticationFilter.java
@@ -89,7 +89,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
           String newRefreshToken = reissueRefreshToken(member);
           tokenService.sendAccessTokenAndRefreshToken(
               response,
-              tokenService.createAccessToken(member.getEmail()),
+              tokenService.createAccessToken(member.getEmail(), member.getMemberId()),
               newRefreshToken);
         }
     );

--- a/src/main/java/com/valuewith/tweaver/commons/security/service/TokenService.java
+++ b/src/main/java/com/valuewith/tweaver/commons/security/service/TokenService.java
@@ -32,6 +32,7 @@ public class TokenService {
   private static final String ACCESS_SUBJECT = "Access";
   private static final String REFRESH_SUBJECT = "Refresh";
   private static final String CLAIM_EMAIL = "email";
+  private static final String CLAIM_MEMBER_ID = "memberId";
   private static final String BEARER = "Bearer ";
 
   private final String accessHeader = "Authorization";
@@ -46,9 +47,10 @@ public class TokenService {
    * Access 토큰을 생성합니다. 페이로드에 들어갈 기본적인 정보는 다음과 같습니다. 1. subject: Access 2. expiration: 1시간 3. claim:
    * email 변경사항 있을시에 claims에 put(클레임 이름, 값) 형식으로 추가해주세요. 클레임 이름은 상수로 추가해주세요. (파싱에서 사용)
    */
-  public String createAccessToken(String email) {
+  public String createAccessToken(String email, Long memberId) {
     Claims claims = Jwts.claims().setSubject(ACCESS_SUBJECT);
     claims.put(CLAIM_EMAIL, email);
+    claims.put(CLAIM_MEMBER_ID, memberId);
 
     Date now = new Date();
     Date expiredDate = new Date(now.getTime() + ACCESS_TOKEN_VALID_TIME);
@@ -86,6 +88,21 @@ public class TokenService {
         token = token.replace(BEARER, "");
       }
       return this.parseClaims(token).get(CLAIM_EMAIL).toString();
+    } catch (Exception e) {
+      System.out.println("들어온 token: " + token);
+      throw new CustomException(INVALID_JWT);
+    }
+  }
+
+  /**
+   * 토큰의 멤버 아이디 정보를 가져옵니다.
+   */
+  public Long getMemberId(String token) {
+    try {
+      if (StringUtils.hasText(token) && token.startsWith(BEARER)) {
+        token = token.replace(BEARER, "");
+      }
+      return Long.parseLong(this.parseClaims(token).get(CLAIM_MEMBER_ID).toString());
     } catch (Exception e) {
       System.out.println("들어온 token: " + token);
       throw new CustomException(INVALID_JWT);


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
AlertController의 `/subscribe` 요청 외에 모든 Api가 MemberRepository를 사용해 Deadlock이 발생합니다.

**TO-BE**
`/subscribe` 요청과 로직을 동일하게 변경하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 