### PR TITLE
refactor: [041-REFACTOR-OAUTH2] 카카오 로그인 성공시 엔드포인트 수정

### DIFF
--- a/src/main/java/com/valuewith/tweaver/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/valuewith/tweaver/auth/handler/OAuth2SuccessHandler.java
@@ -62,7 +62,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
       throw new CustomException(UNVALIDATED_REDIRECT_URI);
     }
 
-    String targetUri = redirectUri.orElse(getDefaultTargetUrl());
+    String targetUri = appProperties.getOAuth2().getAuthorizedRedirectUris().get(0);
     String refreshToken = tokenService.createRefreshToken();
     Optional<Member> member = getMember(authentication);
 

--- a/src/main/java/com/valuewith/tweaver/auth/service/AuthService.java
+++ b/src/main/java/com/valuewith/tweaver/auth/service/AuthService.java
@@ -73,6 +73,7 @@ public class AuthService {
   public Boolean isVerified(AuthDto.VerificationForm form) {
     String emailCode = form.getCode();
     String savedCode = redisUtilService.getData(form.getEmail());
+    // 이부분에 Email이 인증되었다는 값을 Redis에 저장해 두고 signUp에서 가지고 오면 되지 않나?
     if (savedCode.isEmpty()) {
       throw new CustomException(INVALID_CODE);
     }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
카카오 로그인 성공시 포트번호 8080 으로 redirect 되었습니다.

**TO-BE**
카카오 로그인 성공시 `http://localhost:5173/oauth2/callback/kakao` 로 redirect 됩니다.
해당 엔드포인트는 현재 [ValueWithFE](https://github.com/ValueWith/ValueWith_FE)의 kakao login 기능 병합 전이므로 추후 Tweaver 서버 엔드포인트로 재수정될 예정입니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 