### PR TITLE
refactor: [044-SECURITY/SETTINGS] FE 테스트 서버 도메인 security config에 cors 적용

### DIFF
--- a/src/main/java/com/valuewith/tweaver/config/SecurityConfig.java
+++ b/src/main/java/com/valuewith/tweaver/config/SecurityConfig.java
@@ -52,7 +52,8 @@ public class SecurityConfig {
               "https://tweaver.vercel.app",
               "http://localhost:5173",
               "http://127.0.0.1:5173",
-              "https://valuewith.site"
+              "https://valuewith.site",
+              "https://value-with-m8p17yj83-yujinji.vercel.app"
               ));
           config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
           config.setAllowedHeaders(Arrays.asList("*"));

--- a/src/main/java/com/valuewith/tweaver/config/SecurityConfig.java
+++ b/src/main/java/com/valuewith/tweaver/config/SecurityConfig.java
@@ -13,6 +13,7 @@ import com.valuewith.tweaver.commons.security.JwtAuthenticationFilter;
 import com.valuewith.tweaver.commons.security.service.TokenService;
 import com.valuewith.tweaver.member.repository.MemberRepository;
 import java.util.Arrays;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -56,7 +57,7 @@ public class SecurityConfig {
               "https://value-with-m8p17yj83-yujinji.vercel.app"
               ));
           config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-          config.setAllowedHeaders(Arrays.asList("*"));
+          config.setAllowedHeaders(List.of("*"));
           config.setAllowCredentials(true);
           return config;
         }))


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
Tweaver FE 테스트 서버의 도메인을 허용하지 않습니다.

**TO-BE**
Tweaver FE 테스트 서버의 도메인을 허용하였습니다.
https://value-with-m8p17yj83-yujinji.vercel.app 에서 접속이 가능합니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 